### PR TITLE
add credit to the README for junnlikestea

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ $ subdomaingather -d hackerone.com -e Wayback
 ```
 $ subdomaingather -d hackerone.com -v info
 ```
+
+# Credit
+
+- subdomaingather is based heavily on [vita](https://github.com/junnlikestea/vita) by [@junnlikestea](https://github.com/junnlikestea)


### PR DESCRIPTION
Hi, I noticed this project is a lightly updated copy of [vita](https://github.com/junnlikestea/vita). I'm not sure why, but it seems like you cloned the code, removed the git history, and removed all references to the original author and original name, and published it as your own project.

I've compared the code and much of it is identical, as well as the wording in the README, and vita predates this project by a couple of years.

The PR adds the credit back to the original author of the code.